### PR TITLE
Added custom server commands

### DIFF
--- a/CS2-SimpleAdmin.cs
+++ b/CS2-SimpleAdmin.cs
@@ -38,7 +38,7 @@ public partial class CS2_SimpleAdmin : BasePlugin, IPluginConfig<CS2_SimpleAdmin
 	public override string ModuleName => "CS2-SimpleAdmin";
 	public override string ModuleDescription => "Simple admin plugin for Counter-Strike 2 :)";
 	public override string ModuleAuthor => "daffyy & Dliix66";
-	public override string ModuleVersion => "1.3.5a";
+	public override string ModuleVersion => "1.4.0a";
 
 	public CS2_SimpleAdminConfig Config { get; set; } = new();
 

--- a/CS2-SimpleAdmin.cs
+++ b/CS2-SimpleAdmin.cs
@@ -38,7 +38,7 @@ public partial class CS2_SimpleAdmin : BasePlugin, IPluginConfig<CS2_SimpleAdmin
 	public override string ModuleName => "CS2-SimpleAdmin";
 	public override string ModuleDescription => "Simple admin plugin for Counter-Strike 2 :)";
 	public override string ModuleAuthor => "daffyy & Dliix66";
-	public override string ModuleVersion => "1.3.3a";
+	public override string ModuleVersion => "1.4.0a";
 
 	public CS2_SimpleAdminConfig Config { get; set; } = new();
 

--- a/CS2-SimpleAdmin.cs
+++ b/CS2-SimpleAdmin.cs
@@ -38,7 +38,7 @@ public partial class CS2_SimpleAdmin : BasePlugin, IPluginConfig<CS2_SimpleAdmin
 	public override string ModuleName => "CS2-SimpleAdmin";
 	public override string ModuleDescription => "Simple admin plugin for Counter-Strike 2 :)";
 	public override string ModuleAuthor => "daffyy & Dliix66";
-	public override string ModuleVersion => "1.4.0a";
+	public override string ModuleVersion => "1.3.4a";
 
 	public CS2_SimpleAdminConfig Config { get; set; } = new();
 

--- a/CS2-SimpleAdmin.cs
+++ b/CS2-SimpleAdmin.cs
@@ -38,7 +38,7 @@ public partial class CS2_SimpleAdmin : BasePlugin, IPluginConfig<CS2_SimpleAdmin
 	public override string ModuleName => "CS2-SimpleAdmin";
 	public override string ModuleDescription => "Simple admin plugin for Counter-Strike 2 :)";
 	public override string ModuleAuthor => "daffyy & Dliix66";
-	public override string ModuleVersion => "1.4.0a";
+	public override string ModuleVersion => "1.3.5a";
 
 	public CS2_SimpleAdminConfig Config { get; set; } = new();
 

--- a/Config.cs
+++ b/Config.cs
@@ -24,7 +24,7 @@ namespace CS2_SimpleAdmin
 
 	public class CS2_SimpleAdminConfig : BasePluginConfig
 	{
-		public override int Version { get; set; } = 6;
+		public override int Version { get; set; } = 7;
 
 		[JsonPropertyName("DatabaseHost")]
 		public string DatabaseHost { get; set; } = "";

--- a/Config.cs
+++ b/Config.cs
@@ -24,7 +24,7 @@ namespace CS2_SimpleAdmin
 
 	public class CS2_SimpleAdminConfig : BasePluginConfig
 	{
-		public override int Version { get; set; } = 7;
+		[JsonPropertyName("ConfigVersion")] public override int Version { get; set; } = 7;
 
 		[JsonPropertyName("DatabaseHost")]
 		public string DatabaseHost { get; set; } = "";
@@ -64,7 +64,7 @@ namespace CS2_SimpleAdmin
 
 		[JsonPropertyName("WorkshopMaps")]
 		public List<string> WorkshopMaps { get; set; } = new List<string>();
-		
+
 		[JsonPropertyName("CustomServerCommands")]
 		public List<CustomServerCommandData> CustomServerCommands { get; set; } = new List<CustomServerCommandData>();
 	}

--- a/Config.cs
+++ b/Config.cs
@@ -24,7 +24,7 @@ namespace CS2_SimpleAdmin
 
 	public class CS2_SimpleAdminConfig : BasePluginConfig
 	{
-		public override int Version { get; set; } = 7;
+		[JsonPropertyName("ConfigVersion")] public override int Version { get; set; } = 8;
 
 		[JsonPropertyName("DatabaseHost")]
 		public string DatabaseHost { get; set; } = "";
@@ -64,7 +64,7 @@ namespace CS2_SimpleAdmin
 
 		[JsonPropertyName("WorkshopMaps")]
 		public List<string> WorkshopMaps { get; set; } = new List<string>();
-		
+
 		[JsonPropertyName("CustomServerCommands")]
 		public List<CustomServerCommandData> CustomServerCommands { get; set; } = new List<CustomServerCommandData>();
 	}

--- a/Config.cs
+++ b/Config.cs
@@ -12,6 +12,16 @@ namespace CS2_SimpleAdmin
 		public string DiscordPenaltyWebhook { get; set; } = "";
 	}
 
+	public class CustomServerCommandData
+	{
+		[JsonPropertyName("Flag")]
+		public string Flag { get; set; } = "@css/generic";
+		[JsonPropertyName("DisplayName")]
+		public string DisplayName { get; set; } = "";
+		[JsonPropertyName("Command")]
+		public string Command { get; set; } = "";
+	}
+
 	public class CS2_SimpleAdminConfig : BasePluginConfig
 	{
 		public override int Version { get; set; } = 6;
@@ -54,5 +64,8 @@ namespace CS2_SimpleAdmin
 
 		[JsonPropertyName("WorkshopMaps")]
 		public List<string> WorkshopMaps { get; set; } = new List<string>();
+		
+		[JsonPropertyName("CustomServerCommands")]
+		public List<CustomServerCommandData> CustomServerCommands { get; set; } = new List<CustomServerCommandData>();
 	}
 }

--- a/Config.cs
+++ b/Config.cs
@@ -24,7 +24,7 @@ namespace CS2_SimpleAdmin
 
 	public class CS2_SimpleAdminConfig : BasePluginConfig
 	{
-		[JsonPropertyName("ConfigVersion")] public override int Version { get; set; } = 8;
+		public override int Version { get; set; } = 7;
 
 		[JsonPropertyName("DatabaseHost")]
 		public string DatabaseHost { get; set; } = "";
@@ -64,7 +64,7 @@ namespace CS2_SimpleAdmin
 
 		[JsonPropertyName("WorkshopMaps")]
 		public List<string> WorkshopMaps { get; set; } = new List<string>();
-
+		
 		[JsonPropertyName("CustomServerCommands")]
 		public List<CustomServerCommandData> CustomServerCommands { get; set; } = new List<CustomServerCommandData>();
 	}

--- a/Menus/ManageServerMenu.cs
+++ b/Menus/ManageServerMenu.cs
@@ -1,3 +1,4 @@
+using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Modules.Admin;
 using CounterStrikeSharp.API.Modules.Menu;
@@ -34,6 +35,19 @@ namespace CS2_SimpleAdmin.Menus
 
 			options.Add(new ChatMenuOptionData("Restart Game", () => CS2_SimpleAdmin.RestartGame(admin)));
 
+			List<CustomServerCommandData> customCommands = CS2_SimpleAdmin.Instance.Config.CustomServerCommands;
+			foreach (CustomServerCommandData customCommand in customCommands)
+			{
+				if (string.IsNullOrEmpty(customCommand.DisplayName) || string.IsNullOrEmpty(customCommand.Command))
+					continue;
+
+				bool hasRights = AdminManager.PlayerHasPermissions(admin, customCommand.Flag);
+				if (!hasRights)
+					continue;
+
+				options.Add(new ChatMenuOptionData(customCommand.DisplayName, () => Server.ExecuteCommand(customCommand.Command)));
+			}
+
 			foreach (ChatMenuOptionData menuOptionData in options)
 			{
 				string menuName = menuOptionData.name;
@@ -48,7 +62,7 @@ namespace CS2_SimpleAdmin.Menus
 			BaseMenu menu = AdminMenu.CreateMenu($"Change Map");
 			List<ChatMenuOptionData> options = new();
 
-			List<string> maps = CS2_SimpleAdmin.Instance.Config.DefaultMaps;//Server.GetMapList();
+			List<string> maps = CS2_SimpleAdmin.Instance.Config.DefaultMaps;
 			foreach (string map in maps)
 			{
 				options.Add(new ChatMenuOptionData(map, () => ExecuteChangeMap(admin, map, false)));


### PR DESCRIPTION
You can now add custom server commands (under the `Server Management` sub-menu)

Example in config:
```
....
"CustomServerCommands": [
      { "Flag": "@css/root", "DisplayName": "Reload Admins", "Command": "css_admins_reload" },
      { "Flag": "@css/cheat", "DisplayName": "Enable sv_cheats", "Command": "sv_cheats 1" }
  ],
```