### PR TITLE
Add multi-server-per-admin support via sa_admins_servers table

### DIFF
--- a/CS2-SimpleAdmin/CS2-SimpleAdmin.csproj
+++ b/CS2-SimpleAdmin/CS2-SimpleAdmin.csproj
@@ -84,6 +84,9 @@
 	<None Update="Database\Migrations\Mysql\016_OptimizeTablesAndIndexes.sql">
 	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	</None>
+	<None Update="Database\Migrations\Mysql\017_CreateAdminsServersTable.sql">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
 	<None Update="Database\Migrations\Sqlite\001_CreateTables.sql">
 	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	</None>
@@ -130,6 +133,9 @@
 	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	</None>
 	<None Update="Database\Migrations\Sqlite\016_OptimizeTablesAndIndexes.sql">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Update="Database\Migrations\Sqlite\017_CreateAdminsServersTable.sql">
 	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	</None>
 </ItemGroup>

--- a/CS2-SimpleAdmin/Database/IDatabaseProvider.cs
+++ b/CS2-SimpleAdmin/Database/IDatabaseProvider.cs
@@ -21,6 +21,7 @@ public interface IDatabaseProvider
     string GetDeleteAdminQuery(bool globalDelete);
     string GetAddAdminQuery();
     string GetAddAdminFlagsQuery();
+    string GetAddAdminServerQuery();
     string GetUpdateAdminGroupQuery();
     string GetGroupsQuery();
     string GetGroupIdByNameQuery();

--- a/CS2-SimpleAdmin/Database/IDatabaseProvider.cs
+++ b/CS2-SimpleAdmin/Database/IDatabaseProvider.cs
@@ -30,6 +30,7 @@ public interface IDatabaseProvider
     string GetAddGroupServerQuery();
     string GetDeleteGroupQuery();
     string GetDeleteOldAdminsQuery();
+    string GetDeleteOrphanedAdminsQuery();
     
     // BanManager
     string GetAddBanQuery();

--- a/CS2-SimpleAdmin/Database/Migrations/Mysql/017_CreateAdminsServersTable.sql
+++ b/CS2-SimpleAdmin/Database/Migrations/Mysql/017_CreateAdminsServersTable.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS `sa_admins_servers` (
+ `id` int(11) NOT NULL AUTO_INCREMENT,
+ `admin_id` int(11) NOT NULL,
+ `server_id` int(11) NOT NULL,
+ PRIMARY KEY (`id`),
+ FOREIGN KEY (`admin_id`) REFERENCES `sa_admins` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+ALTER TABLE `sa_admins` ADD `global` TINYINT(1) NOT NULL DEFAULT 0;
+
+INSERT INTO `sa_admins_servers` (`admin_id`, `server_id`)
+SELECT `id`, `server_id` FROM `sa_admins` WHERE `server_id` IS NOT NULL;
+
+UPDATE `sa_admins` SET `global` = 1 WHERE `server_id` IS NULL;
+
+ALTER TABLE `sa_admins` DROP COLUMN `server_id`;

--- a/CS2-SimpleAdmin/Database/Migrations/Sqlite/017_CreateAdminsServersTable.sql
+++ b/CS2-SimpleAdmin/Database/Migrations/Sqlite/017_CreateAdminsServersTable.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS `sa_admins_servers` (
+    `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    `admin_id` INTEGER NOT NULL,
+    `server_id` INTEGER NOT NULL,
+    FOREIGN KEY (`admin_id`) REFERENCES `sa_admins` (`id`) ON DELETE CASCADE
+);
+
+ALTER TABLE `sa_admins` ADD `global` INTEGER NOT NULL DEFAULT 0;
+
+INSERT INTO `sa_admins_servers` (`admin_id`, `server_id`)
+SELECT `id`, `server_id` FROM `sa_admins` WHERE `server_id` IS NOT NULL;
+
+UPDATE `sa_admins` SET `global` = 1 WHERE `server_id` IS NULL;
+
+ALTER TABLE `sa_admins` DROP COLUMN `server_id`;

--- a/CS2-SimpleAdmin/Database/MysqlDatabaseProvider.cs
+++ b/CS2-SimpleAdmin/Database/MysqlDatabaseProvider.cs
@@ -187,6 +187,9 @@ public class MySqlDatabaseProvider(string connectionString) : IDatabaseProvider
 
     public string GetDeleteOldAdminsQuery() =>
         "DELETE FROM sa_admins WHERE ends IS NOT NULL AND ends <= @CurrentTime;";
+
+    public string GetDeleteOrphanedAdminsQuery() =>
+        "DELETE FROM sa_admins WHERE `global` = 0 AND id NOT IN (SELECT admin_id FROM sa_admins_servers);";
     
     public string GetAddBanQuery()
     {

--- a/CS2-SimpleAdmin/Database/MysqlDatabaseProvider.cs
+++ b/CS2-SimpleAdmin/Database/MysqlDatabaseProvider.cs
@@ -127,7 +127,10 @@ public class MySqlDatabaseProvider(string connectionString) : IDatabaseProvider
                FROM sa_admins_flags
                JOIN sa_admins ON sa_admins_flags.admin_id = sa_admins.id
                WHERE (sa_admins.ends IS NULL OR sa_admins.ends > @CurrentTime)
-               AND (sa_admins.server_id IS NULL OR sa_admins.server_id = @serverid)
+               AND (sa_admins.`global` = 1
+                    OR EXISTS (SELECT 1 FROM sa_admins_servers
+                               WHERE sa_admins_servers.admin_id = sa_admins.id
+                               AND sa_admins_servers.server_id = @serverid))
                ORDER BY sa_admins.player_steamid
                """;
     }
@@ -135,11 +138,14 @@ public class MySqlDatabaseProvider(string connectionString) : IDatabaseProvider
     public string GetDeleteAdminQuery(bool globalDelete) =>
         globalDelete
             ? "DELETE FROM sa_admins WHERE player_steamid = @PlayerSteamID"
-            : "DELETE FROM sa_admins WHERE player_steamid = @PlayerSteamID AND server_id = @ServerId";
-    
+            : "DELETE FROM sa_admins_servers WHERE server_id = @ServerId AND admin_id IN (SELECT id FROM sa_admins WHERE player_steamid = @PlayerSteamID)";
+
     public string GetAddAdminQuery() =>
-        "INSERT INTO sa_admins (player_steamid, player_name, immunity, ends, created, server_id) " +
-        "VALUES (@playerSteamId, @playerName, @immunity, @ends, @created, @serverid); SELECT LAST_INSERT_ID();";
+        "INSERT INTO sa_admins (player_steamid, player_name, immunity, ends, created, `global`) " +
+        "VALUES (@playerSteamId, @playerName, @immunity, @ends, @created, @isGlobal); SELECT LAST_INSERT_ID();";
+
+    public string GetAddAdminServerQuery() =>
+        "INSERT INTO sa_admins_servers (admin_id, server_id) VALUES (@adminId, @server_id);";
 
     public string GetGroupsQuery()
     {

--- a/CS2-SimpleAdmin/Database/SqliteDatabaseProvider.cs
+++ b/CS2-SimpleAdmin/Database/SqliteDatabaseProvider.cs
@@ -240,6 +240,9 @@ public class SqliteDatabaseProvider(string filePath) : IDatabaseProvider
 
     public string GetDeleteOldAdminsQuery() =>
         "DELETE FROM sa_admins WHERE ends IS NOT NULL AND ends <= @CurrentTime;";
+
+    public string GetDeleteOrphanedAdminsQuery() =>
+        "DELETE FROM sa_admins WHERE `global` = 0 AND id NOT IN (SELECT admin_id FROM sa_admins_servers);";
     
     public string GetAddMuteQuery(bool includePlayerName) =>
         includePlayerName

--- a/CS2-SimpleAdmin/Database/SqliteDatabaseProvider.cs
+++ b/CS2-SimpleAdmin/Database/SqliteDatabaseProvider.cs
@@ -176,21 +176,27 @@ public class SqliteDatabaseProvider(string filePath) : IDatabaseProvider
         FROM sa_admins_flags
         JOIN sa_admins ON sa_admins_flags.admin_id = sa_admins.id
         WHERE (sa_admins.ends IS NULL OR sa_admins.ends > @CurrentTime)
-          AND (sa_admins.server_id IS NULL OR sa_admins.server_id = @serverid)
+          AND (sa_admins.`global` = 1
+               OR EXISTS (SELECT 1 FROM sa_admins_servers
+                          WHERE sa_admins_servers.admin_id = sa_admins.id
+                          AND sa_admins_servers.server_id = @serverid))
         ORDER BY sa_admins.player_steamid
         """;
 
     public string GetDeleteAdminQuery(bool globalDelete) =>
         globalDelete
             ? "DELETE FROM sa_admins WHERE player_steamid = @PlayerSteamID"
-            : "DELETE FROM sa_admins WHERE player_steamid = @PlayerSteamID AND server_id = @ServerId";
+            : "DELETE FROM sa_admins_servers WHERE server_id = @ServerId AND admin_id IN (SELECT id FROM sa_admins WHERE player_steamid = @PlayerSteamID)";
 
     public string GetAddAdminQuery() =>
         """
-        INSERT INTO sa_admins (player_steamid, player_name, immunity, ends, created, server_id)
-        VALUES (@playerSteamId, @playerName, @immunity, @ends, @created, @serverid);
+        INSERT INTO sa_admins (player_steamid, player_name, immunity, ends, created, `global`)
+        VALUES (@playerSteamId, @playerName, @immunity, @ends, @created, @isGlobal);
         SELECT last_insert_rowid();
         """;
+
+    public string GetAddAdminServerQuery() =>
+        "INSERT INTO sa_admins_servers (admin_id, server_id) VALUES (@adminId, @server_id);";
 
     public string GetGroupsQuery() =>
         """

--- a/CS2-SimpleAdmin/Managers/PermissionManager.cs
+++ b/CS2-SimpleAdmin/Managers/PermissionManager.cs
@@ -530,7 +530,7 @@ public class PermissionManager(IDatabaseProvider? databaseProvider)
                 immunity,
                 ends = futureTime,
                 created = now,
-                serverid = globalAdmin ? null : CS2_SimpleAdmin.ServerId
+                isGlobal = globalAdmin ? 1 : 0
             });
 
             // Insert flags into sa_admins_flags table
@@ -560,6 +560,18 @@ public class PermissionManager(IDatabaseProvider? databaseProvider)
                 {
                     adminId,
                     flag
+                });
+            }
+
+            // Global admins apply to every server and need no per-server link row.
+            // Server-specific admins are linked to the current server.
+            if (!globalAdmin)
+            {
+                var insertAdminServerSql = databaseProvider.GetAddAdminServerQuery();
+                await connection.ExecuteAsync(insertAdminServerSql, new
+                {
+                    adminId,
+                    server_id = CS2_SimpleAdmin.ServerId
                 });
             }
 

--- a/CS2-SimpleAdmin/Managers/PermissionManager.cs
+++ b/CS2-SimpleAdmin/Managers/PermissionManager.cs
@@ -677,4 +677,24 @@ public class PermissionManager(IDatabaseProvider? databaseProvider)
             CS2_SimpleAdmin._logger?.LogCritical("Unable to remove expired admins");
         }
     }
+
+    /// <summary>
+    /// Deletes orphaned admins that are not global and have no server assignments left.
+    /// </summary>
+    public async Task DeleteOrphanedAdmins()
+    {
+        if (databaseProvider == null) return;
+
+        try
+        {
+            await using var connection = await databaseProvider.CreateConnectionAsync();
+
+            var sql = databaseProvider.GetDeleteOrphanedAdminsQuery();
+            await connection.ExecuteAsync(sql);
+        }
+        catch (Exception)
+        {
+            CS2_SimpleAdmin._logger?.LogCritical("Unable to remove orphaned admins");
+        }
+    }
 }

--- a/CS2-SimpleAdmin/Managers/PlayerManager.cs
+++ b/CS2-SimpleAdmin/Managers/PlayerManager.cs
@@ -306,7 +306,8 @@ internal class PlayerManager
                         pluginInstance.MuteManager.ExpireOldMutes(),
                         pluginInstance.WarnManager.ExpireOldWarns(),
                         pluginInstance.CacheManager?.RefreshCacheAsync() ?? Task.CompletedTask,
-                        pluginInstance.PermissionManager.DeleteOldAdmins()
+                        pluginInstance.PermissionManager.DeleteOldAdmins(),
+                        pluginInstance.PermissionManager.DeleteOrphanedAdmins()
                     };
 
                     await Task.WhenAll(expireTasks);


### PR DESCRIPTION
## Summary

Admin records are bound to a **single** server through the `sa_admins.server_id` column (`NULL` = global). Granting one admin to several specific servers means duplicating the whole admin row (plus its flag rows) per server, and "all servers" is modelled as a `NULL` foreign-key value, which is awkward to query and easy to get wrong.

This PR introduces a **`sa_admins_servers` link table** — mirroring the existing `sa_groups` / `sa_groups_servers` pattern — so a single admin record can be attached to many servers. It also adds an explicit **`global` flag** on `sa_admins` for all-servers admins, replacing the `NULL`-`server_id` convention. Existing data is migrated automatically and behaviour is preserved.

## Changes

All changes are additive/mechanical against `eea700b`.

- **Migration `017_CreateAdminsServersTable.sql` (MySQL + SQLite)** — creates `sa_admins_servers (id, admin_id, server_id NOT NULL, FK admin_id → sa_admins(id) ON DELETE CASCADE)`; adds `global` column to `sa_admins` (default `0`); backfills (server-specific admins → one link row each, old `NULL`-server admins → `global = 1`); then drops `sa_admins.server_id`. Both new files are registered in the `.csproj` for `CopyToOutputDirectory`, matching every other migration.
- **`IDatabaseProvider`** — adds `GetAddAdminServerQuery()` and `GetDeleteOrphanedAdminsQuery()`.
- **`MysqlDatabaseProvider` / `SqliteDatabaseProvider`** (symmetric):
  - `GetAdminsQuery` — now selects admins where `global = 1` **OR** a `sa_admins_servers` row exists for the current server (via `EXISTS`, so the flag join doesn't multiply rows). Previously filtered on `sa_admins.server_id`.
  - `GetAddAdminQuery` — inserts the `global` column instead of `server_id`.
  - `GetAddAdminServerQuery` — inserts the per-server link row.
  - `GetDeleteAdminQuery(globalDelete: false)` — deletes only the current server's link row, leaving the admin and its other server assignments intact. Global delete still removes the `sa_admins` row (cascading the links).
  - `GetDeleteOrphanedAdminsQuery` — deletes non-global admins that have no remaining `sa_admins_servers` rows (see Notes).
- **`PermissionManager`** — `AddAdminBySteamId`: `-g` sets `global = 1` and writes **no** link row (applies everywhere); otherwise `global = 0` and a link row is written for the current server. New `DeleteOrphanedAdmins()` runs the orphan-cleanup query.
- **`PlayerManager`** — `DeleteOrphanedAdmins()` is added to the existing expire-timer task batch (alongside `DeleteOldAdmins()`), so orphans are swept on the same cadence as expired bans/mutes/warns.
- The `global` identifier is a MySQL reserved word, so it is backticked in every statement.

## Test plan

- [x] **SQLite migration backfill** — synthetic `sa_admins` (one `NULL`-server, two server-specific) run through `017`: `NULL` admin → `global = 1` with no link row; server-specific admins → one link row each with correct `server_id`; `sa_admins.server_id` dropped; `sa_admins_servers.server_id` enforced `NOT NULL`. (SQLite 3.50.4 via System.Data.SQLite.Core 1.0.119.)
- [x] **SQLite load query** — `GetAdminsQuery` returns, per server: server 5 → global + server-5 admin; server 7 → global + server-7 admin; unregistered server 9 → global only.
- [x] **SQLite orphan sweep** — after a non-global delete strips an admin's last link, `GetDeleteOrphanedAdminsQuery` removes exactly that admin (`global = 0`, no links) while leaving the global admin and a still-linked admin untouched.
- [x] **`dotnet build` (Rebuild, net8.0)** — clean, 0 warnings / 0 errors.
- [ ] **MySQL** — not retested by submitter (no MySQL test env handy). The SQL mirrors the existing `sa_groups_servers` patterns and existing admin queries; `EXISTS`, the `global` backfill, `DROP COLUMN`, and the orphan `DELETE … NOT IN (subquery on a different table)` are all standard MySQL. A second pair of eyes on a MySQL deployment before merge would be welcome.
- [ ] **Live in-game smoke test** — recommend a quick `css_addadmin` (with and without `-g`) and `css_deladmin` on a running server at merge time to confirm permission load/unload end-to-end.

## Notes

- **Backward compatible.** Existing global and server-specific admins keep working unchanged after the migration; no manual data steps required.
- **Orphan handling.** A non-global delete only removes the current server's link row, so an admin can be left with `global = 0` and zero links — invisible to every server (never loaded) but still occupying rows. `DeleteOrphanedAdmins()` sweeps these on the expire timer so they don't accumulate.
- **SQLite FK cascade caveat (pre-existing, unchanged).** SQLite connections in `SqliteDatabaseProvider` don't issue `PRAGMA foreign_keys = ON`, so `ON DELETE CASCADE` doesn't fire on SQLite — exactly as with the existing `sa_admins_flags` table. This means an orphaned admin's `sa_admins_flags` rows can linger on SQLite after the admin row is swept; MySQL cascades them. Enabling the pragma globally would fix this class of issue but is a separate cleanup, out of scope here.
- The `globalAdmin`/`-g` plumbing in `basecommands.cs` is left as-is; it now drives the `global` column instead of a `NULL` `server_id`.

Tested SA version: `eea700b`. Submitted from `Ravid-A:feature/multi-server-per-admin`.
