### PR TITLE
fix: OverflowException in CacheManager when reading negative IP values from SQLite

### DIFF
--- a/CS2-SimpleAdmin/Managers/CacheManager.cs
+++ b/CS2-SimpleAdmin/Managers/CacheManager.cs
@@ -73,7 +73,7 @@ internal class CacheManager: IDisposable
             if (CS2_SimpleAdmin.Instance.Config.OtherSettings.CheckMultiAccountsByIp)
             {
                 // Optimization: Load IP history and build cache in single pass
-                var ipHistory = await connection.QueryAsync<(ulong steamid, string? name, uint address, DateTime used_at)>(
+                var ipHistory = await connection.QueryAsync<(ulong steamid, string? name, long address, DateTime used_at)>(
                     "SELECT steamid, name, address, used_at FROM sa_players_ips ORDER BY steamid, address, used_at DESC");
 
                 var unknownName = CS2_SimpleAdmin._localizer?["sa_unknown"] ?? "Unknown";
@@ -94,12 +94,12 @@ internal class CacheManager: IDisposable
                     currentSteamId = record.steamid;
 
                     // Only keep the latest timestamp for each IP
-                    if (!latestIpTimestamps.TryGetValue(record.address, out var existingTimestamp) ||
+                    if (!latestIpTimestamps.TryGetValue(((uint)(record.address & 0xFFFFFFFF)), out var existingTimestamp) ||
                         record.used_at > existingTimestamp)
                     {
-                        latestIpTimestamps[record.address] = record.used_at;
+                        latestIpTimestamps[((uint)(record.address & 0xFFFFFFFF))] = record.used_at;
                         currentIpSet.Add(new IpRecord(
-                            record.address,
+                            ((uint)(record.address & 0xFFFFFFFF)),
                             record.used_at,
                             string.IsNullOrEmpty(record.name) ? unknownName : record.name
                         ));
@@ -283,7 +283,7 @@ internal class CacheManager: IDisposable
             
             if (CS2_SimpleAdmin.Instance.Config.OtherSettings.CheckMultiAccountsByIp)
             {
-                var ipHistory = (await connection.QueryAsync<(ulong steamid, string? name, uint address, DateTime used_at)>(
+                var ipHistory = (await connection.QueryAsync<(ulong steamid, string? name, long address, DateTime used_at)>(
                     "SELECT steamid, name, address, used_at FROM sa_players_ips WHERE used_at >= @lastUpdate ORDER BY used_at DESC LIMIT 300",
                     new { lastUpdate = _lastUpdateTime }));
 
@@ -291,7 +291,7 @@ internal class CacheManager: IDisposable
                 {
                     var ipSet = new HashSet<IpRecord>(
                         group
-                            .GroupBy(x => x.address)
+                            .GroupBy(x => (uint)(x.address & 0xFFFFFFFF))
                             .Select(g =>
                             {
                                 var latest = g.MaxBy(x => x.used_at);


### PR DESCRIPTION
## Problem

SQLite stores uint values > 2,147,483,647 as negative int64. When Dapper deserializes the `address` column from `sa_players_ips` into a `uint` tuple field, values like -1250625110 (which represents a valid IP as uint: 3044342186) cause a `System.OverflowException`.

This causes:
- Exception on every server start during `InitializeCacheAsync()`
- Progressive server performance degradation (slow-motion gameplay) after 12-18 hours of uptime
- Only fixable by server restart

## Fix

Changes the query tuple type from `uint` to `long` and adds an explicit cast `(uint)(value & 0xFFFFFFFF)` to safely convert both positive and negative stored values back to the correct uint representation.

## Affected users

SQLite users with IP addresses in the upper half of the uint range (IPs > 128.x.x.x), which is the majority of public IPs.

## Testing

Tested on 4 production servers running CS2-SimpleAdmin 1.7.9a with CSS 1.0.369. The OverflowException no longer occurs on startup and servers maintain stable performance over extended periods.