### PR TITLE
Fix SQLite IP history materialization

### DIFF
--- a/CS2-SimpleAdmin/Models/IpHistoryRow.cs
+++ b/CS2-SimpleAdmin/Models/IpHistoryRow.cs
@@ -1,3 +1,14 @@
 namespace CS2_SimpleAdmin.Models;
 
-public record IpHistoryRow(ulong Steamid, string? Name, uint Address, DateTime Used_at);
+public sealed class IpHistoryRow
+{
+    public long steamid { get; set; }
+    public string? name { get; set; }
+    public long address { get; set; }
+    public DateTime used_at { get; set; }
+
+    public ulong Steamid => Convert.ToUInt64(steamid);
+    public string? Name => name;
+    public uint Address => unchecked((uint)address);
+    public DateTime Used_at => used_at;
+}


### PR DESCRIPTION
## Summary
- replace IpHistoryRow's positional ulong/uint record with a parameterless DTO for Dapper/SQLite mapping
- keep the public PascalCase accessors used by CacheManager
- preserve signed SQLite IPv4 bit patterns with an unchecked uint cast

## Why
In 1.8.2a, SQLite can still fail during CacheManager.InitializeCacheAsync when CheckMultiAccountsByIp is enabled. SQLite/Dapper materializes integer values as Int64, and existing sa_players_ips.address rows may contain signed 32-bit IPv4 values. The current positional record can fail either during materialization or when converting address values to uint.

## Verification
- Built CS2-SimpleAdmin with net10.0: 0 errors
- Runtime-verified on a SQLite server with CheckMultiAccountsByIp=true: SimpleAdmin logs Loaded server with ip ... followed by Loaded admins!, with no IpHistoryRow/DataException/OverflowException stack trace.